### PR TITLE
[#67] 주변 사용자 검색 기능 향상

### DIFF
--- a/src/main/java/com/stoury/dto/member/MemberDistance.java
+++ b/src/main/java/com/stoury/dto/member/MemberDistance.java
@@ -1,4 +1,0 @@
-package com.stoury.dto.member;
-
-public record MemberDistance(Long memberId, int distance) {
-}

--- a/src/main/java/com/stoury/dto/member/OnlineMember.java
+++ b/src/main/java/com/stoury/dto/member/OnlineMember.java
@@ -3,9 +3,7 @@ package com.stoury.dto.member;
 import com.stoury.domain.Member;
 
 public record OnlineMember(Long memberId, String username, String email, int distance) {
-    public static OnlineMember from(Member member, MemberDistance memberDistance) {
-        return new OnlineMember(
-                member.getId(), member.getUsername(), member.getEmail(), memberDistance.distance()
-        );
+    public static OnlineMember from(Member member, int distance) {
+        return new OnlineMember(member.getId(), member.getUsername(), member.getEmail(), distance);
     }
 }

--- a/src/main/java/com/stoury/repository/MemberOnlineStatusRepository.java
+++ b/src/main/java/com/stoury/repository/MemberOnlineStatusRepository.java
@@ -1,7 +1,7 @@
 package com.stoury.repository;
 
-import com.stoury.dto.member.MemberDistance;
 import com.stoury.exception.location.GetMemberPositionsException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.geo.*;
 import org.springframework.data.redis.connection.RedisGeoCommands;
@@ -11,9 +11,12 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Repository
 public class MemberOnlineStatusRepository {
     public static final String ONLINE_MEMBER_CACHE_KEY = "online:member:";
@@ -42,24 +45,39 @@ public class MemberOnlineStatusRepository {
         opsForGeo.remove(MEMBER_POS_CACHE_KEY, memberId.toString());
     }
 
-    public List<MemberDistance> findByPoint(Point point, double radiusKm) {
+    public Map<Long, Integer> findByPoint(Point point, double radiusKm) {
         Circle within = new Circle(point, new Distance(radiusKm, Metrics.KILOMETERS));
         RedisGeoCommands.GeoRadiusCommandArgs args = RedisGeoCommands.GeoRadiusCommandArgs.newGeoRadiusArgs()
                 .includeDistance()
                 .sortAscending();
+        long start = System.currentTimeMillis();
         List<GeoResult<RedisGeoCommands.GeoLocation<String>>> geoResults = Optional.ofNullable(opsForGeo.radius(MEMBER_POS_CACHE_KEY, within, args))
                 .orElseThrow(GetMemberPositionsException::new)
                 .getContent();
+        long end = System.currentTimeMillis();
+        log.debug("geoRadius latency: {}", end - start);
 
         return geoResults.stream()
-                .map(this::memberDistances)
-                .toList();
+                .filter(this::nonNull)
+                .map(res -> Map.entry(getId(res), getDistance(res)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private MemberDistance memberDistances(GeoResult<RedisGeoCommands.GeoLocation<String>> geoResult) {
-        String memberId = geoResult.getContent().getName();
-        double distance = geoResult.getDistance().in(Metrics.KILOMETERS).getValue();
+    private boolean nonNull(GeoResult<RedisGeoCommands.GeoLocation<String>> geoResult){
+        if(geoResult.getContent().getName() == null){
+            log.error("Null member Id is stored. Check the online member redis storage.");
+            return false;
+        }
+        return true;
+    }
 
-        return new MemberDistance(Long.parseLong(memberId), (int)distance);
+    private Long getId(GeoResult<RedisGeoCommands.GeoLocation<String>> geoResult){
+        String memberIdStr = geoResult.getContent().getName();
+        return Long.valueOf(memberIdStr);
+    }
+
+    private Integer getDistance(GeoResult<RedisGeoCommands.GeoLocation<String>> geoResult) {
+        double distance = geoResult.getDistance().in(Metrics.KILOMETERS).getValue();
+        return (int)distance;
     }
 }

--- a/src/main/java/com/stoury/repository/MemberOnlineStatusRepository.java
+++ b/src/main/java/com/stoury/repository/MemberOnlineStatusRepository.java
@@ -50,12 +50,9 @@ public class MemberOnlineStatusRepository {
         RedisGeoCommands.GeoRadiusCommandArgs args = RedisGeoCommands.GeoRadiusCommandArgs.newGeoRadiusArgs()
                 .includeDistance()
                 .sortAscending();
-        long start = System.currentTimeMillis();
         List<GeoResult<RedisGeoCommands.GeoLocation<String>>> geoResults = Optional.ofNullable(opsForGeo.radius(MEMBER_POS_CACHE_KEY, within, args))
                 .orElseThrow(GetMemberPositionsException::new)
                 .getContent();
-        long end = System.currentTimeMillis();
-        log.debug("geoRadius latency: {}", end - start);
 
         return geoResults.stream()
                 .filter(this::nonNull)

--- a/src/test/groovy/com/stoury/service/MemberServiceTest.groovy
+++ b/src/test/groovy/com/stoury/service/MemberServiceTest.groovy
@@ -2,7 +2,7 @@ package com.stoury.service
 
 import com.stoury.domain.Member
 import com.stoury.dto.member.MemberCreateRequest
-import com.stoury.dto.member.MemberDistance
+
 import com.stoury.dto.member.MemberUpdateRequest
 import com.stoury.exception.member.MemberCreateException
 import com.stoury.exception.member.MemberDeleteException
@@ -11,7 +11,6 @@ import com.stoury.exception.member.MemberUpdateException
 import com.stoury.repository.MemberOnlineStatusRepository
 import com.stoury.repository.MemberRepository
 import com.stoury.service.storage.StorageService
-import org.springframework.data.util.Pair
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.security.crypto.password.PasswordEncoder
 import spock.lang.Specification
@@ -149,17 +148,12 @@ class MemberServiceTest extends Specification {
 
     def "주변 사용자 검색"() {
         given:
-        memberOnlineStatusRepository.findByPoint(_, _) >> List.of(
-                new MemberDistance(3, 10),
-                new MemberDistance(2, 20),
-                new MemberDistance(1, 30),
-        )
-        def member1 = new Member("member1@email.com", "pwdpwd1", "member1", null)
-        def member2 = new Member("member2@email.com", "pwdpwd1", "member2", null)
-        def member3 = new Member("member3@email.com", "pwdpwd1", "member3", null)
-        memberRepository.findById(1) >> Optional.of(member1)
-        memberRepository.findById(2) >> Optional.of(member2)
-        memberRepository.findById(3) >> Optional.of(member3)
+        memberOnlineStatusRepository.findByPoint(_, _) >> [3L:10, 2L:20, 1L:30]
+
+        def member1 = new Member(id:1L, email:"member1@email.com", encryptedPassword:"pwdpwd1", username:"member1", introduction: null)
+        def member2 = new Member(id:2L, email:"member2@email.com", encryptedPassword:"pwdpwd1", username:"member2", introduction: null)
+        def member3 = new Member(id:3L, email:"member3@email.com", encryptedPassword:"pwdpwd1", username:"member3", introduction: null)
+        memberRepository.findAllById(_) >> [member2, member1, member3]
         when:
         def aroundMembers = memberService.searchOnlineMembers(4, 10.0, 10.0, 50.0)
         then:
@@ -170,17 +164,12 @@ class MemberServiceTest extends Specification {
 
     def "주변 사용자 검색-사용자 본인은 제외되어야 함"() {
         given:
-        memberOnlineStatusRepository.findByPoint(_, _) >> List.of(
-                new MemberDistance(3, 10),
-                new MemberDistance(2, 20),
-                new MemberDistance(1, 30),
-        )
-        def member1 = new Member("member1@email.com", "pwdpwd1", "member1", null)
-        def member2 = new Member("member2@email.com", "pwdpwd1", "member2", null)
-        def member3 = new Member("member3@email.com", "pwdpwd1", "member3", null)
-        memberRepository.findById(1) >> Optional.of(member1)
-        memberRepository.findById(2) >> Optional.of(member2)
-        memberRepository.findById(3) >> Optional.of(member3)
+        memberOnlineStatusRepository.findByPoint(_, _) >> [3L:10, 2L:20, 1L:30]
+
+        def member1 = new Member(id:1L, email:"member1@email.com", encryptedPassword:"pwdpwd1", username:"member1", introduction: null)
+        def member2 = new Member(id:2L, email:"member2@email.com", encryptedPassword:"pwdpwd1", username:"member2", introduction: null)
+        def member3 = new Member(id:3L, email:"member3@email.com", encryptedPassword:"pwdpwd1", username:"member3", introduction: null)
+        memberRepository.findAllById(_) >> [member2, member1, member3]
         when:
         def aroundMembers = memberService.searchOnlineMembers(2, 10.0, 10.0, 50.0)
         then:


### PR DESCRIPTION
- 기존 : 레디스로 가져온 사용자 id마다 db로 쿼리를 날림
- 개선 : 사용자 id 셋으로 `IN` 조회를 하여 한번에 모든 사용자를 가져오도록 수정 